### PR TITLE
Add speed analytics, NPC browser, and Location browser

### DIFF
--- a/backend/tools/campaign_tools.py
+++ b/backend/tools/campaign_tools.py
@@ -125,16 +125,18 @@ def search_characters(
     ctx: RunContext[CampaignDeps],
     name: str = "",
     character_type: str = "",
+    tag: str = "",
 ) -> str:
     """Search for characters in this campaign. You can filter by name
-    (partial match) and/or type (pc, npc, companion, deity). Returns
-    name, race, class, level, description, and status."""
+    (partial match), type (pc, npc, companion, deity), and/or tag.
+    Returns name, race, class, level, description, tags, relationships,
+    and status."""
 
     query = (
         ctx.deps.supabase.table("characters")
         .select(
             "name, type, race, class, level, alignment, status, "
-            "description, backstory"
+            "description, backstory, tags, relationships, portrait_url"
         )
         .eq("campaign_id", ctx.deps.campaign_id)
     )
@@ -142,6 +144,8 @@ def search_characters(
         query = query.ilike("name", f"%{name}%")
     if character_type:
         query = query.eq("type", character_type)
+    if tag:
+        query = query.contains("tags", [tag])
 
     result = query.limit(15).execute()
     characters = result.data or []
@@ -151,6 +155,8 @@ def search_characters(
             filter_desc += f" matching '{name}'"
         if character_type:
             filter_desc += f" of type '{character_type}'"
+        if tag:
+            filter_desc += f" tagged '{tag}'"
         return f"No characters found{filter_desc}."
 
     lines = []
@@ -161,6 +167,11 @@ def search_characters(
             f"{ch.get('class', '?')}, Level {ch.get('level', '?')}): "
             f"{desc} [Status: {ch.get('status', '?')}]"
         )
+        if ch.get("tags"):
+            lines.append(f"  Tags: {', '.join(ch['tags'])}")
+        if ch.get("relationships"):
+            rels = [f"{r['name']} ({r['relation']})" for r in ch["relationships"]]
+            lines.append(f"  Relationships: {', '.join(rels)}")
         if ch.get("backstory"):
             backstory = ch["backstory"]
             if len(backstory) > 200:
@@ -205,23 +216,34 @@ def search_notes(
 
 
 def get_locations(
-    ctx: RunContext[CampaignDeps], name: str = ""
+    ctx: RunContext[CampaignDeps], name: str = "", tag: str = ""
 ) -> str:
     """Get locations in this campaign. Optionally filter by name (partial
-    match). Returns name, type, description, and parent location."""
+    match) and/or tag. Returns name, type, description, tags,
+    relationships, and parent location."""
 
     query = (
         ctx.deps.supabase.table("locations")
-        .select("id, name, type, description, parent_location_id")
+        .select(
+            "id, name, type, description, parent_location_id, "
+            "tags, relationships, image_url"
+        )
         .eq("campaign_id", ctx.deps.campaign_id)
     )
     if name:
         query = query.ilike("name", f"%{name}%")
+    if tag:
+        query = query.contains("tags", [tag])
 
     result = query.limit(20).execute()
     locations = result.data or []
     if not locations:
-        return f"No locations found{' matching ' + repr(name) if name else ''}."
+        filter_desc = ""
+        if name:
+            filter_desc += f" matching '{name}'"
+        if tag:
+            filter_desc += f" tagged '{tag}'"
+        return f"No locations found{filter_desc}."
 
     # Build parent lookup for hierarchy
     all_locs_res = (
@@ -242,6 +264,11 @@ def get_locations(
         if len(desc) > 200:
             desc = desc[:200] + "..."
         lines.append(f"- {loc['name']} ({loc['type']}){parent}: {desc}")
+        if loc.get("tags"):
+            lines.append(f"  Tags: {', '.join(loc['tags'])}")
+        if loc.get("relationships"):
+            rels = [f"{r['name']} ({r['relation']})" for r in loc["relationships"]]
+            lines.append(f"  Relationships: {', '.join(rels)}")
     return "\n".join(lines)
 
 
@@ -530,6 +557,188 @@ def add_timeline_event(
     return "Failed to record timeline event."
 
 
+def create_character(
+    ctx: RunContext[CampaignDeps],
+    name: str,
+    character_type: str = "npc",
+    race: str = "",
+    char_class: str = "",
+    description: str = "",
+    backstory: str = "",
+    tags: list[str] | None = None,
+    relationships: list[dict] | None = None,
+) -> str:
+    """Create a new character (NPC, companion, or deity) in this campaign.
+    Only the DM can create characters via this tool. Tags should be short
+    descriptive labels. Relationships are [{name, relation}] objects."""
+
+    if ctx.deps.role != "dm":
+        return "Only the DM can create characters."
+
+    data = {
+        "campaign_id": ctx.deps.campaign_id,
+        "name": name,
+        "type": character_type,
+        "visibility": "public",
+    }
+    if race:
+        data["race"] = race
+    if char_class:
+        data["class"] = char_class
+    if description:
+        data["description"] = description
+    if backstory:
+        data["backstory"] = backstory
+    if tags:
+        data["tags"] = tags
+    if relationships:
+        data["relationships"] = relationships
+
+    result = ctx.deps.supabase.table("characters").insert(data).execute()
+    if result.data:
+        return f"Created {character_type} '{name}' successfully."
+    return f"Failed to create character '{name}'."
+
+
+def update_character(
+    ctx: RunContext[CampaignDeps],
+    character_name: str,
+    description: str = "",
+    backstory: str = "",
+    tags: list[str] | None = None,
+    relationships: list[dict] | None = None,
+) -> str:
+    """Update an existing character's description, backstory, tags, or
+    relationships. Only the DM can update characters via this tool."""
+
+    if ctx.deps.role != "dm":
+        return "Only the DM can update characters."
+
+    char_res = (
+        ctx.deps.supabase.table("characters")
+        .select("id, name")
+        .eq("campaign_id", ctx.deps.campaign_id)
+        .ilike("name", f"%{character_name}%")
+        .limit(1)
+        .execute()
+    )
+    characters = char_res.data or []
+    if not characters:
+        return f"No character found matching '{character_name}'."
+
+    ch = characters[0]
+    updates = {}
+    if description:
+        updates["description"] = description
+    if backstory:
+        updates["backstory"] = backstory
+    if tags is not None:
+        updates["tags"] = tags
+    if relationships is not None:
+        updates["relationships"] = relationships
+
+    if not updates:
+        return "No updates provided."
+
+    ctx.deps.supabase.table("characters").update(updates).eq("id", ch["id"]).execute()
+    return f"Updated character '{ch['name']}' successfully."
+
+
+def create_location(
+    ctx: RunContext[CampaignDeps],
+    name: str,
+    location_type: str = "city",
+    description: str = "",
+    notes: str = "",
+    tags: list[str] | None = None,
+    relationships: list[dict] | None = None,
+    parent_location_name: str = "",
+) -> str:
+    """Create a new location in this campaign. Only the DM can create
+    locations. location_type must be one of: continent, region, city,
+    town, village, dungeon, building, room, wilderness, plane."""
+
+    if ctx.deps.role != "dm":
+        return "Only the DM can create locations."
+
+    data = {
+        "campaign_id": ctx.deps.campaign_id,
+        "name": name,
+        "type": location_type,
+        "visibility": "public",
+    }
+    if description:
+        data["description"] = description
+    if notes:
+        data["notes"] = notes
+    if tags:
+        data["tags"] = tags
+    if relationships:
+        data["relationships"] = relationships
+
+    # Resolve parent location by name
+    if parent_location_name:
+        parent_res = (
+            ctx.deps.supabase.table("locations")
+            .select("id")
+            .eq("campaign_id", ctx.deps.campaign_id)
+            .ilike("name", f"%{parent_location_name}%")
+            .limit(1)
+            .execute()
+        )
+        if parent_res.data:
+            data["parent_location_id"] = parent_res.data[0]["id"]
+
+    result = ctx.deps.supabase.table("locations").insert(data).execute()
+    if result.data:
+        return f"Created {location_type} '{name}' successfully."
+    return f"Failed to create location '{name}'."
+
+
+def update_location(
+    ctx: RunContext[CampaignDeps],
+    location_name: str,
+    description: str = "",
+    notes: str = "",
+    tags: list[str] | None = None,
+    relationships: list[dict] | None = None,
+) -> str:
+    """Update an existing location's description, notes, tags, or
+    relationships. Only the DM can update locations."""
+
+    if ctx.deps.role != "dm":
+        return "Only the DM can update locations."
+
+    loc_res = (
+        ctx.deps.supabase.table("locations")
+        .select("id, name")
+        .eq("campaign_id", ctx.deps.campaign_id)
+        .ilike("name", f"%{location_name}%")
+        .limit(1)
+        .execute()
+    )
+    locations = loc_res.data or []
+    if not locations:
+        return f"No location found matching '{location_name}'."
+
+    loc = locations[0]
+    updates = {}
+    if description:
+        updates["description"] = description
+    if notes:
+        updates["notes"] = notes
+    if tags is not None:
+        updates["tags"] = tags
+    if relationships is not None:
+        updates["relationships"] = relationships
+
+    if not updates:
+        return "No updates provided."
+
+    ctx.deps.supabase.table("locations").update(updates).eq("id", loc["id"]).execute()
+    return f"Updated location '{loc['name']}' successfully."
+
+
 def update_mission_status(
     ctx: RunContext[CampaignDeps],
     mission_title: str,
@@ -582,6 +791,10 @@ READ_TOOLS = [
 WRITE_TOOLS = [
     add_note,
     update_character_status,
+    create_character,
+    update_character,
+    create_location,
+    update_location,
     add_timeline_event,
     update_mission_status,
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.99.3",
         "@tailwindcss/vite": "^4.2.2",
+        "@vercel/speed-insights": "^2.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1"
@@ -1231,6 +1232,44 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
@@ -1378,9 +1417,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2595,9 +2634,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.99.3",
     "@tailwindcss/vite": "^4.2.2",
+    "@vercel/speed-insights": "^2.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import CreateCampaign from './pages/CreateCampaign'
 import JoinCampaign from './pages/JoinCampaign'
 import CampaignView from './pages/CampaignView'
 import Account from './pages/Account'
+import { SpeedInsights } from '@vercel/speed-insights/react'
 
 export default function App() {
   const { session, loading, signInWithGoogle, signOut } = useAuth()
@@ -40,6 +41,7 @@ export default function App() {
           <Route path="/account" element={<Account session={session} profile={profile} updateProfile={updateProfile} />} />
         </Routes>
       </Layout>
+      <SpeedInsights />
     </BrowserRouter>
   )
 }

--- a/src/pages/CampaignView.jsx
+++ b/src/pages/CampaignView.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
 import { supabase } from '../lib/supabase'
 import Sessions from './Sessions'
+import NPCs from './NPCs'
+import Locations from './Locations'
 import Chat from './Chat'
 import Reference from './Reference'
 import AdventureViewer from './AdventureViewer'
@@ -114,6 +116,18 @@ export default function CampaignView({ session }) {
             >
               Sessions
             </button>
+            <button
+              style={leftTab === 'npcs' ? styles.panelTabActive : styles.panelTab}
+              onClick={() => setLeftTab('npcs')}
+            >
+              NPCs
+            </button>
+            <button
+              style={leftTab === 'locations' ? styles.panelTabActive : styles.panelTab}
+              onClick={() => setLeftTab('locations')}
+            >
+              Locations
+            </button>
             {campaign.adventure_source && (
               <button
                 style={leftTab === 'adventure' ? styles.panelTabActive : styles.panelTab}
@@ -126,6 +140,12 @@ export default function CampaignView({ session }) {
           <div style={styles.panelContent}>
             {leftTab === 'sessions' && (
               <Sessions campaignId={id} session={session} role={role} />
+            )}
+            {leftTab === 'npcs' && (
+              <NPCs campaignId={id} session={session} role={role} />
+            )}
+            {leftTab === 'locations' && (
+              <Locations campaignId={id} session={session} role={role} />
             )}
             {leftTab === 'adventure' && campaign.adventure_source && (
               <AdventureViewer code={campaign.adventure_source} />

--- a/src/pages/Locations.jsx
+++ b/src/pages/Locations.jsx
@@ -1,0 +1,802 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+
+export default function Locations({ campaignId, session, role }) {
+  const [locations, setLocations] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [selectedId, setSelectedId] = useState(null)
+  const [showCreate, setShowCreate] = useState(false)
+
+  // Create form state
+  const [form, setForm] = useState({
+    name: '', type: 'city', description: '', notes: '',
+    tags: '', image_url: '', parent_location_id: '',
+  })
+  const [relationships, setRelationships] = useState([])
+  const [creating, setCreating] = useState(false)
+
+  useEffect(() => { fetchLocations() }, [campaignId])
+
+  async function fetchLocations() {
+    const { data } = await supabase
+      .from('locations')
+      .select('*')
+      .eq('campaign_id', campaignId)
+      .order('name')
+    if (data) setLocations(data)
+    setLoading(false)
+  }
+
+  async function createLocation() {
+    if (!form.name.trim()) return
+    setCreating(true)
+
+    const tags = form.tags.split(',').map(t => t.trim()).filter(Boolean)
+    const rels = relationships.filter(r => r.name.trim() && r.relation.trim())
+
+    const insertData = {
+      campaign_id: campaignId,
+      name: form.name.trim(),
+      type: form.type,
+      description: form.description.trim() || null,
+      notes: form.notes.trim() || null,
+      image_url: form.image_url.trim() || null,
+      tags,
+      relationships: rels,
+      visibility: 'public',
+    }
+    if (form.parent_location_id) {
+      insertData.parent_location_id = form.parent_location_id
+    }
+
+    const { data, error } = await supabase
+      .from('locations')
+      .insert(insertData)
+      .select()
+      .single()
+
+    if (!error && data) {
+      setLocations([...locations, data].sort((a, b) => a.name.localeCompare(b.name)))
+      setForm({ name: '', type: 'city', description: '', notes: '', tags: '', image_url: '', parent_location_id: '' })
+      setRelationships([])
+      setShowCreate(false)
+      setSelectedId(data.id)
+    }
+    setCreating(false)
+  }
+
+  async function updateLocation(id, updates) {
+    const { error } = await supabase
+      .from('locations')
+      .update(updates)
+      .eq('id', id)
+    if (!error) {
+      setLocations(prev => prev.map(l => l.id === id ? { ...l, ...updates } : l))
+    }
+    return !error
+  }
+
+  async function deleteLocation(id) {
+    if (!window.confirm('Delete this location? This cannot be undone.')) return
+    const { error } = await supabase.from('locations').delete().eq('id', id)
+    if (!error) {
+      setLocations(prev => prev.filter(l => l.id !== id))
+      setSelectedId(null)
+    }
+  }
+
+  // Build parent name map
+  const locMap = Object.fromEntries(locations.map(l => [l.id, l.name]))
+
+  const filtered = locations.filter(l => {
+    if (!search.trim()) return true
+    const q = search.toLowerCase()
+    return (
+      l.name.toLowerCase().includes(q) ||
+      (l.description || '').toLowerCase().includes(q) ||
+      (l.tags || []).some(t => t.toLowerCase().includes(q)) ||
+      l.type.toLowerCase().includes(q)
+    )
+  })
+
+  // Detail view
+  if (selectedId) {
+    const loc = locations.find(l => l.id === selectedId)
+    if (!loc) { setSelectedId(null); return null }
+    return (
+      <LocationDetail
+        location={loc}
+        locMap={locMap}
+        allLocations={locations}
+        role={role}
+        onBack={() => { setSelectedId(null); fetchLocations() }}
+        onUpdate={updateLocation}
+        onDelete={deleteLocation}
+      />
+    )
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <h2 style={styles.title}>Locations</h2>
+        {role === 'dm' && (
+          <button style={styles.button} onClick={() => setShowCreate(!showCreate)}>
+            {showCreate ? 'Cancel' : 'Add Location'}
+          </button>
+        )}
+      </div>
+
+      {showCreate && (
+        <div style={styles.createForm}>
+          <div style={styles.row}>
+            <input style={{ ...styles.input, flex: 1 }} value={form.name}
+              onChange={e => setForm({ ...form, name: e.target.value })}
+              placeholder="Location name *" autoFocus />
+            <select style={styles.select} value={form.type}
+              onChange={e => setForm({ ...form, type: e.target.value })}>
+              {LOCATION_TYPES.map(t => (
+                <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+              ))}
+            </select>
+          </div>
+          {locations.length > 0 && (
+            <select style={styles.select} value={form.parent_location_id}
+              onChange={e => setForm({ ...form, parent_location_id: e.target.value })}>
+              <option value="">No parent location</option>
+              {locations.map(l => (
+                <option key={l.id} value={l.id}>{l.name} ({l.type})</option>
+              ))}
+            </select>
+          )}
+          <textarea style={styles.textarea} value={form.description}
+            onChange={e => setForm({ ...form, description: e.target.value })}
+            placeholder="Description — what this place looks like, who lives here..." rows={3} />
+          {role === 'dm' && (
+            <textarea style={styles.textarea} value={form.notes}
+              onChange={e => setForm({ ...form, notes: e.target.value })}
+              placeholder="DM notes (private)" rows={2} />
+          )}
+          <input style={styles.input} value={form.tags}
+            onChange={e => setForm({ ...form, tags: e.target.value })}
+            placeholder="Tags (comma-separated, e.g. safe haven, shop, dungeon)" />
+          <input style={styles.input} value={form.image_url}
+            onChange={e => setForm({ ...form, image_url: e.target.value })}
+            placeholder="Image URL (optional)" />
+
+          <div style={styles.relSection}>
+            <span style={styles.relLabel}>Relationships</span>
+            {relationships.map((r, i) => (
+              <div key={i} style={styles.row}>
+                <input style={{ ...styles.input, flex: 1 }} value={r.name}
+                  onChange={e => {
+                    const copy = [...relationships]
+                    copy[i] = { ...copy[i], name: e.target.value }
+                    setRelationships(copy)
+                  }} placeholder="Name" />
+                <input style={{ ...styles.input, flex: 1 }} value={r.relation}
+                  onChange={e => {
+                    const copy = [...relationships]
+                    copy[i] = { ...copy[i], relation: e.target.value }
+                    setRelationships(copy)
+                  }} placeholder="Relation (e.g. trade route, border)" />
+                <button style={styles.removeBtn}
+                  onClick={() => setRelationships(relationships.filter((_, j) => j !== i))}>
+                  x
+                </button>
+              </div>
+            ))}
+            <button style={styles.addRelBtn}
+              onClick={() => setRelationships([...relationships, { name: '', relation: '' }])}>
+              + Add Relationship
+            </button>
+          </div>
+
+          <button style={styles.button} onClick={createLocation}
+            disabled={creating || !form.name.trim()}>
+            {creating ? 'Creating...' : 'Create Location'}
+          </button>
+        </div>
+      )}
+
+      <input style={styles.searchInput} value={search}
+        onChange={e => setSearch(e.target.value)}
+        placeholder="Search by name, description, tag, or type..." />
+
+      {loading ? (
+        <p style={styles.muted}>Loading locations...</p>
+      ) : filtered.length === 0 ? (
+        <div style={styles.empty}>
+          <p style={styles.emptyText}>
+            {search ? 'No locations match your search.' : 'No locations yet.'}
+          </p>
+          {!search && role === 'dm' && (
+            <p style={styles.muted}>Add your first location to start building the world.</p>
+          )}
+        </div>
+      ) : (
+        <div style={styles.list}>
+          {filtered.map(loc => (
+            <button key={loc.id} style={styles.card} onClick={() => setSelectedId(loc.id)}>
+              <div style={styles.cardRow}>
+                {loc.image_url && (
+                  <img src={loc.image_url} alt="" style={styles.thumbnail} />
+                )}
+                <div style={styles.cardInfo}>
+                  <div style={styles.cardTop}>
+                    <span style={styles.cardName}>{loc.name}</span>
+                    <span style={styles.typeBadge}>
+                      {loc.type.toUpperCase()}
+                    </span>
+                  </div>
+                  {loc.parent_location_id && locMap[loc.parent_location_id] && (
+                    <span style={styles.parentMeta}>in {locMap[loc.parent_location_id]}</span>
+                  )}
+                  {loc.description && (
+                    <p style={styles.preview}>
+                      {loc.description.length > 100 ? loc.description.substring(0, 100) + '...' : loc.description}
+                    </p>
+                  )}
+                  {loc.tags && loc.tags.length > 0 && (
+                    <div style={styles.tagRow}>
+                      {loc.tags.map((t, i) => (
+                        <span key={i} style={styles.tag}>{t}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Location Detail View
+// ---------------------------------------------------------------------------
+
+function LocationDetail({ location, locMap, allLocations, role, onBack, onUpdate, onDelete }) {
+  const loc = location
+  const [editing, setEditing] = useState(false)
+  const [form, setForm] = useState({})
+  const [relForm, setRelForm] = useState([])
+  const [saving, setSaving] = useState(false)
+
+  // Child locations
+  const children = allLocations.filter(l => l.parent_location_id === loc.id)
+
+  function startEdit() {
+    setForm({
+      description: loc.description || '',
+      notes: loc.notes || '',
+      tags: (loc.tags || []).join(', '),
+      image_url: loc.image_url || '',
+      type: loc.type,
+      parent_location_id: loc.parent_location_id || '',
+    })
+    setRelForm(loc.relationships && loc.relationships.length > 0
+      ? loc.relationships.map(r => ({ ...r }))
+      : [])
+    setEditing(true)
+  }
+
+  async function save() {
+    setSaving(true)
+    const tags = form.tags.split(',').map(t => t.trim()).filter(Boolean)
+    const rels = relForm.filter(r => r.name.trim() && r.relation.trim())
+    const success = await onUpdate(loc.id, {
+      description: form.description.trim() || null,
+      notes: form.notes.trim() || null,
+      tags,
+      relationships: rels,
+      image_url: form.image_url.trim() || null,
+      type: form.type,
+      parent_location_id: form.parent_location_id || null,
+    })
+    if (success) setEditing(false)
+    setSaving(false)
+  }
+
+  return (
+    <div style={styles.detailContainer}>
+      <button style={styles.backBtn} onClick={onBack}>&larr; Back to Locations</button>
+
+      {loc.image_url && (
+        <img src={loc.image_url} alt={loc.name} style={styles.heroImage} />
+      )}
+
+      <div style={styles.detailHeader}>
+        <div>
+          <h2 style={styles.detailName}>{loc.name}</h2>
+          <div style={styles.detailMeta}>
+            <span style={styles.typeBadge}>{loc.type.toUpperCase()}</span>
+            {loc.parent_location_id && locMap[loc.parent_location_id] && (
+              <span style={styles.metaItem}>in {locMap[loc.parent_location_id]}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {editing ? (
+        <div style={styles.editForm}>
+          <div style={styles.row}>
+            <select style={styles.select} value={form.type}
+              onChange={e => setForm({ ...form, type: e.target.value })}>
+              {LOCATION_TYPES.map(t => (
+                <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>
+              ))}
+            </select>
+            <select style={{ ...styles.select, flex: 1 }} value={form.parent_location_id}
+              onChange={e => setForm({ ...form, parent_location_id: e.target.value })}>
+              <option value="">No parent location</option>
+              {allLocations.filter(l => l.id !== loc.id).map(l => (
+                <option key={l.id} value={l.id}>{l.name} ({l.type})</option>
+              ))}
+            </select>
+          </div>
+          <textarea style={styles.textarea} value={form.description}
+            onChange={e => setForm({ ...form, description: e.target.value })}
+            placeholder="Description" rows={4} />
+          {role === 'dm' && (
+            <textarea style={styles.textarea} value={form.notes}
+              onChange={e => setForm({ ...form, notes: e.target.value })}
+              placeholder="DM notes (private)" rows={3} />
+          )}
+          <input style={styles.input} value={form.tags}
+            onChange={e => setForm({ ...form, tags: e.target.value })}
+            placeholder="Tags (comma-separated)" />
+          <input style={styles.input} value={form.image_url}
+            onChange={e => setForm({ ...form, image_url: e.target.value })}
+            placeholder="Image URL" />
+
+          <div style={styles.relSection}>
+            <span style={styles.relLabel}>Relationships</span>
+            {relForm.map((r, i) => (
+              <div key={i} style={styles.row}>
+                <input style={{ ...styles.input, flex: 1 }} value={r.name}
+                  onChange={e => {
+                    const copy = [...relForm]
+                    copy[i] = { ...copy[i], name: e.target.value }
+                    setRelForm(copy)
+                  }} placeholder="Name" />
+                <input style={{ ...styles.input, flex: 1 }} value={r.relation}
+                  onChange={e => {
+                    const copy = [...relForm]
+                    copy[i] = { ...copy[i], relation: e.target.value }
+                    setRelForm(copy)
+                  }} placeholder="Relation" />
+                <button style={styles.removeBtn}
+                  onClick={() => setRelForm(relForm.filter((_, j) => j !== i))}>x</button>
+              </div>
+            ))}
+            <button style={styles.addRelBtn}
+              onClick={() => setRelForm([...relForm, { name: '', relation: '' }])}>
+              + Add Relationship
+            </button>
+          </div>
+
+          <div style={styles.row}>
+            <button style={styles.button} onClick={save} disabled={saving}>
+              {saving ? 'Saving...' : 'Save Changes'}
+            </button>
+            <button style={styles.cancelBtn} onClick={() => setEditing(false)}>Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <div style={styles.detailBody}>
+          {loc.description && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Description</h3>
+              <p style={styles.sectionText}>{loc.description}</p>
+            </div>
+          )}
+
+          {role === 'dm' && loc.notes && (
+            <div style={{ ...styles.section, ...styles.dmNotesBox }}>
+              <h3 style={styles.sectionTitle}>DM Notes</h3>
+              <p style={styles.sectionText}>{loc.notes}</p>
+            </div>
+          )}
+
+          {loc.tags && loc.tags.length > 0 && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Tags</h3>
+              <div style={styles.tagRow}>
+                {loc.tags.map((t, i) => <span key={i} style={styles.tag}>{t}</span>)}
+              </div>
+            </div>
+          )}
+
+          {loc.relationships && loc.relationships.length > 0 && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Relationships</h3>
+              <div style={styles.relList}>
+                {loc.relationships.map((r, i) => (
+                  <div key={i} style={styles.relItem}>
+                    <span style={styles.relName}>{r.name}</span>
+                    <span style={styles.relType}>{r.relation}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {children.length > 0 && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Contains</h3>
+              <div style={styles.childList}>
+                {children.map(c => (
+                  <span key={c.id} style={styles.childChip}>
+                    {c.name} ({c.type})
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {role === 'dm' && (
+            <div style={styles.detailActions}>
+              <button style={styles.button} onClick={startEdit}>Edit</button>
+              <button style={styles.deleteBtn} onClick={() => onDelete(loc.id)}>Delete</button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Constants & Styles
+// ---------------------------------------------------------------------------
+
+const LOCATION_TYPES = [
+  'continent', 'region', 'city', 'town', 'village',
+  'dungeon', 'building', 'room', 'wilderness', 'plane',
+]
+
+const styles = {
+  container: {
+    maxWidth: '720px',
+    margin: '0 auto',
+    padding: '1.5rem',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '1rem',
+  },
+  title: {
+    margin: 0,
+    fontSize: '1.25rem',
+    color: '#1e293b',
+  },
+  button: {
+    padding: '0.5rem 1rem',
+    borderRadius: '8px',
+    backgroundColor: '#2563eb',
+    color: '#fff',
+    border: 'none',
+    fontSize: '0.875rem',
+    cursor: 'pointer',
+  },
+  cancelBtn: {
+    padding: '0.5rem 1rem',
+    borderRadius: '8px',
+    backgroundColor: 'transparent',
+    color: '#64748b',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.875rem',
+    cursor: 'pointer',
+  },
+  deleteBtn: {
+    padding: '0.5rem 1rem',
+    borderRadius: '8px',
+    backgroundColor: 'transparent',
+    border: '1px solid #fca5a5',
+    color: '#dc2626',
+    fontSize: '0.875rem',
+    cursor: 'pointer',
+  },
+  searchInput: {
+    width: '100%',
+    padding: '0.6rem 0.75rem',
+    borderRadius: '8px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.875rem',
+    outline: 'none',
+    marginBottom: '1rem',
+    boxSizing: 'border-box',
+  },
+  createForm: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    marginBottom: '1rem',
+    padding: '1rem',
+    borderRadius: '10px',
+    border: '1px solid #e2e8f0',
+    backgroundColor: '#f8fafc',
+  },
+  editForm: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    marginTop: '1rem',
+  },
+  row: {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'center',
+  },
+  input: {
+    padding: '0.5rem 0.75rem',
+    borderRadius: '6px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.85rem',
+    outline: 'none',
+  },
+  select: {
+    padding: '0.5rem 0.75rem',
+    borderRadius: '6px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.85rem',
+    outline: 'none',
+    backgroundColor: '#fff',
+  },
+  textarea: {
+    padding: '0.5rem 0.75rem',
+    borderRadius: '6px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.85rem',
+    outline: 'none',
+    resize: 'vertical',
+    fontFamily: 'inherit',
+    lineHeight: 1.5,
+  },
+  relSection: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.35rem',
+  },
+  relLabel: {
+    fontSize: '0.8rem',
+    fontWeight: 600,
+    color: '#475569',
+  },
+  addRelBtn: {
+    padding: '0.3rem 0.6rem',
+    borderRadius: '6px',
+    backgroundColor: 'transparent',
+    border: '1px dashed #94a3b8',
+    color: '#64748b',
+    fontSize: '0.75rem',
+    cursor: 'pointer',
+    alignSelf: 'flex-start',
+  },
+  removeBtn: {
+    padding: '0.3rem 0.5rem',
+    borderRadius: '4px',
+    backgroundColor: 'transparent',
+    border: '1px solid #fca5a5',
+    color: '#dc2626',
+    fontSize: '0.75rem',
+    cursor: 'pointer',
+    lineHeight: 1,
+  },
+  muted: {
+    color: '#94a3b8',
+    fontSize: '0.9rem',
+  },
+  empty: {
+    textAlign: 'center',
+    padding: '3rem 1rem',
+    backgroundColor: '#f8fafc',
+    borderRadius: '12px',
+    border: '1px dashed #cbd5e1',
+  },
+  emptyText: {
+    margin: '0 0 0.25rem 0',
+    color: '#334155',
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '0.75rem 1rem',
+    borderRadius: '10px',
+    border: '1px solid #e2e8f0',
+    backgroundColor: '#fff',
+    textAlign: 'left',
+    cursor: 'pointer',
+    width: '100%',
+    fontFamily: 'inherit',
+  },
+  cardRow: {
+    display: 'flex',
+    gap: '0.75rem',
+    alignItems: 'flex-start',
+  },
+  thumbnail: {
+    width: '48px',
+    height: '48px',
+    borderRadius: '8px',
+    objectFit: 'cover',
+    flexShrink: 0,
+  },
+  cardInfo: {
+    flex: 1,
+    minWidth: 0,
+  },
+  cardTop: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: '0.5rem',
+  },
+  cardName: {
+    fontSize: '0.95rem',
+    fontWeight: 600,
+    color: '#1e293b',
+  },
+  typeBadge: {
+    fontSize: '0.65rem',
+    fontWeight: 600,
+    padding: '0.15rem 0.4rem',
+    borderRadius: '4px',
+    backgroundColor: '#e0f2fe',
+    color: '#0369a1',
+    flexShrink: 0,
+  },
+  parentMeta: {
+    fontSize: '0.75rem',
+    color: '#94a3b8',
+    fontStyle: 'italic',
+  },
+  meta: {
+    fontSize: '0.8rem',
+    color: '#64748b',
+  },
+  metaItem: {
+    fontSize: '0.8rem',
+    color: '#64748b',
+  },
+  preview: {
+    margin: '0.25rem 0 0 0',
+    fontSize: '0.8rem',
+    color: '#64748b',
+    lineHeight: 1.4,
+  },
+  tagRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.3rem',
+    marginTop: '0.35rem',
+  },
+  tag: {
+    fontSize: '0.65rem',
+    padding: '0.1rem 0.4rem',
+    borderRadius: '4px',
+    backgroundColor: '#f1f5f9',
+    color: '#475569',
+    border: '1px solid #e2e8f0',
+  },
+  // Detail styles
+  detailContainer: {
+    maxWidth: '720px',
+    margin: '0 auto',
+    padding: '1.5rem',
+  },
+  backBtn: {
+    padding: '0.4rem 0',
+    background: 'none',
+    border: 'none',
+    color: '#2563eb',
+    fontSize: '0.85rem',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+    marginBottom: '1rem',
+  },
+  heroImage: {
+    width: '100%',
+    maxHeight: '200px',
+    objectFit: 'cover',
+    borderRadius: '10px',
+    marginBottom: '1rem',
+  },
+  detailHeader: {
+    marginBottom: '1.5rem',
+    paddingBottom: '1rem',
+    borderBottom: '1px solid #e2e8f0',
+  },
+  detailName: {
+    margin: '0 0 0.35rem 0',
+    fontSize: '1.35rem',
+    color: '#1e293b',
+  },
+  detailMeta: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.4rem',
+    alignItems: 'center',
+  },
+  detailBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1.25rem',
+  },
+  section: {},
+  sectionTitle: {
+    margin: '0 0 0.35rem 0',
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    color: '#475569',
+    textTransform: 'uppercase',
+    letterSpacing: '0.03em',
+  },
+  sectionText: {
+    margin: 0,
+    fontSize: '0.9rem',
+    color: '#334155',
+    lineHeight: 1.6,
+    whiteSpace: 'pre-wrap',
+  },
+  dmNotesBox: {
+    padding: '0.75rem',
+    borderRadius: '8px',
+    backgroundColor: '#fefce8',
+    border: '1px solid #fef08a',
+  },
+  relList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.35rem',
+  },
+  relItem: {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'center',
+    padding: '0.4rem 0.6rem',
+    borderRadius: '6px',
+    backgroundColor: '#f8fafc',
+    border: '1px solid #e2e8f0',
+  },
+  relName: {
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    color: '#1e293b',
+  },
+  relType: {
+    fontSize: '0.8rem',
+    color: '#64748b',
+    fontStyle: 'italic',
+  },
+  childList: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.35rem',
+  },
+  childChip: {
+    fontSize: '0.8rem',
+    padding: '0.25rem 0.5rem',
+    borderRadius: '6px',
+    backgroundColor: '#e0f2fe',
+    color: '#0369a1',
+    border: '1px solid #bae6fd',
+  },
+  detailActions: {
+    display: 'flex',
+    gap: '0.5rem',
+    paddingTop: '1rem',
+    borderTop: '1px solid #e2e8f0',
+  },
+}

--- a/src/pages/NPCs.jsx
+++ b/src/pages/NPCs.jsx
@@ -1,0 +1,790 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../lib/supabase'
+
+export default function NPCs({ campaignId, session, role }) {
+  const [characters, setCharacters] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [search, setSearch] = useState('')
+  const [selectedId, setSelectedId] = useState(null)
+  const [showCreate, setShowCreate] = useState(false)
+
+  // Create form state
+  const [form, setForm] = useState({
+    name: '', type: 'npc', race: '', class: '', description: '',
+    backstory: '', tags: '', portrait_url: '',
+  })
+  const [relationships, setRelationships] = useState([])
+  const [creating, setCreating] = useState(false)
+
+  useEffect(() => { fetchCharacters() }, [campaignId])
+
+  async function fetchCharacters() {
+    const { data } = await supabase
+      .from('characters')
+      .select('*')
+      .eq('campaign_id', campaignId)
+      .order('name')
+    if (data) setCharacters(data)
+    setLoading(false)
+  }
+
+  async function createCharacter() {
+    if (!form.name.trim()) return
+    setCreating(true)
+
+    const tags = form.tags
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean)
+
+    const rels = relationships.filter(r => r.name.trim() && r.relation.trim())
+
+    const { data, error } = await supabase
+      .from('characters')
+      .insert({
+        campaign_id: campaignId,
+        name: form.name.trim(),
+        type: form.type,
+        race: form.race.trim() || null,
+        class: form.class.trim() || null,
+        description: form.description.trim() || null,
+        backstory: form.backstory.trim() || null,
+        portrait_url: form.portrait_url.trim() || null,
+        tags,
+        relationships: rels,
+        visibility: 'public',
+      })
+      .select()
+      .single()
+
+    if (!error && data) {
+      setCharacters([...characters, data].sort((a, b) => a.name.localeCompare(b.name)))
+      setForm({ name: '', type: 'npc', race: '', class: '', description: '', backstory: '', tags: '', portrait_url: '' })
+      setRelationships([])
+      setShowCreate(false)
+      setSelectedId(data.id)
+    }
+    setCreating(false)
+  }
+
+  async function updateCharacter(id, updates) {
+    const { error } = await supabase
+      .from('characters')
+      .update(updates)
+      .eq('id', id)
+    if (!error) {
+      setCharacters(prev => prev.map(c => c.id === id ? { ...c, ...updates } : c))
+    }
+    return !error
+  }
+
+  async function deleteCharacter(id) {
+    if (!window.confirm('Delete this character? This cannot be undone.')) return
+    const { error } = await supabase.from('characters').delete().eq('id', id)
+    if (!error) {
+      setCharacters(prev => prev.filter(c => c.id !== id))
+      setSelectedId(null)
+    }
+  }
+
+  const filtered = characters.filter(c => {
+    if (!search.trim()) return true
+    const q = search.toLowerCase()
+    return (
+      c.name.toLowerCase().includes(q) ||
+      (c.description || '').toLowerCase().includes(q) ||
+      (c.tags || []).some(t => t.toLowerCase().includes(q)) ||
+      (c.race || '').toLowerCase().includes(q) ||
+      (c.class || '').toLowerCase().includes(q)
+    )
+  })
+
+  // Detail view
+  if (selectedId) {
+    const ch = characters.find(c => c.id === selectedId)
+    if (!ch) { setSelectedId(null); return null }
+    return (
+      <CharacterDetail
+        character={ch}
+        role={role}
+        onBack={() => { setSelectedId(null); fetchCharacters() }}
+        onUpdate={updateCharacter}
+        onDelete={deleteCharacter}
+      />
+    )
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <h2 style={styles.title}>NPCs & Characters</h2>
+        {role === 'dm' && (
+          <button style={styles.button} onClick={() => setShowCreate(!showCreate)}>
+            {showCreate ? 'Cancel' : 'Add Character'}
+          </button>
+        )}
+      </div>
+
+      {showCreate && (
+        <div style={styles.createForm}>
+          <div style={styles.row}>
+            <input style={{ ...styles.input, flex: 1 }} value={form.name}
+              onChange={e => setForm({ ...form, name: e.target.value })}
+              placeholder="Name *" autoFocus />
+            <select style={styles.select} value={form.type}
+              onChange={e => setForm({ ...form, type: e.target.value })}>
+              <option value="npc">NPC</option>
+              <option value="pc">PC</option>
+              <option value="companion">Companion</option>
+              <option value="deity">Deity</option>
+            </select>
+          </div>
+          <div style={styles.row}>
+            <input style={{ ...styles.input, flex: 1 }} value={form.race}
+              onChange={e => setForm({ ...form, race: e.target.value })}
+              placeholder="Race (e.g. Human, Elf)" />
+            <input style={{ ...styles.input, flex: 1 }} value={form.class}
+              onChange={e => setForm({ ...form, class: e.target.value })}
+              placeholder="Class (e.g. Rogue, Wizard)" />
+          </div>
+          <textarea style={styles.textarea} value={form.description}
+            onChange={e => setForm({ ...form, description: e.target.value })}
+            placeholder="Description — appearance, personality, role..." rows={3} />
+          <textarea style={styles.textarea} value={form.backstory}
+            onChange={e => setForm({ ...form, backstory: e.target.value })}
+            placeholder="Backstory (optional)" rows={2} />
+          <input style={styles.input} value={form.tags}
+            onChange={e => setForm({ ...form, tags: e.target.value })}
+            placeholder="Tags (comma-separated, e.g. tavern keeper, quest giver, ally)" />
+          <input style={styles.input} value={form.portrait_url}
+            onChange={e => setForm({ ...form, portrait_url: e.target.value })}
+            placeholder="Portrait image URL (optional)" />
+
+          <div style={styles.relSection}>
+            <span style={styles.relLabel}>Relationships</span>
+            {relationships.map((r, i) => (
+              <div key={i} style={styles.row}>
+                <input style={{ ...styles.input, flex: 1 }} value={r.name}
+                  onChange={e => {
+                    const copy = [...relationships]
+                    copy[i] = { ...copy[i], name: e.target.value }
+                    setRelationships(copy)
+                  }} placeholder="Name" />
+                <input style={{ ...styles.input, flex: 1 }} value={r.relation}
+                  onChange={e => {
+                    const copy = [...relationships]
+                    copy[i] = { ...copy[i], relation: e.target.value }
+                    setRelationships(copy)
+                  }} placeholder="Relation (e.g. enemy, ally)" />
+                <button style={styles.removeBtn}
+                  onClick={() => setRelationships(relationships.filter((_, j) => j !== i))}>
+                  x
+                </button>
+              </div>
+            ))}
+            <button style={styles.addRelBtn}
+              onClick={() => setRelationships([...relationships, { name: '', relation: '' }])}>
+              + Add Relationship
+            </button>
+          </div>
+
+          <button style={styles.button} onClick={createCharacter}
+            disabled={creating || !form.name.trim()}>
+            {creating ? 'Creating...' : 'Create Character'}
+          </button>
+        </div>
+      )}
+
+      <input style={styles.searchInput} value={search}
+        onChange={e => setSearch(e.target.value)}
+        placeholder="Search by name, description, tag, race, or class..." />
+
+      {loading ? (
+        <p style={styles.muted}>Loading characters...</p>
+      ) : filtered.length === 0 ? (
+        <div style={styles.empty}>
+          <p style={styles.emptyText}>
+            {search ? 'No characters match your search.' : 'No characters yet.'}
+          </p>
+          {!search && role === 'dm' && (
+            <p style={styles.muted}>Add your first NPC to get started.</p>
+          )}
+        </div>
+      ) : (
+        <div style={styles.list}>
+          {filtered.map(ch => (
+            <button key={ch.id} style={styles.card} onClick={() => setSelectedId(ch.id)}>
+              <div style={styles.cardRow}>
+                {ch.portrait_url && (
+                  <img src={ch.portrait_url} alt="" style={styles.thumbnail} />
+                )}
+                <div style={styles.cardInfo}>
+                  <div style={styles.cardTop}>
+                    <span style={styles.cardName}>{ch.name}</span>
+                    <span style={{
+                      ...styles.typeBadge,
+                      backgroundColor: typeColors[ch.type] || '#e2e8f0',
+                    }}>{ch.type.toUpperCase()}</span>
+                  </div>
+                  {(ch.race || ch.class) && (
+                    <span style={styles.meta}>
+                      {[ch.race, ch.class, ch.level ? `Lvl ${ch.level}` : ''].filter(Boolean).join(' · ')}
+                    </span>
+                  )}
+                  {ch.description && (
+                    <p style={styles.preview}>
+                      {ch.description.length > 100 ? ch.description.substring(0, 100) + '...' : ch.description}
+                    </p>
+                  )}
+                  {ch.tags && ch.tags.length > 0 && (
+                    <div style={styles.tagRow}>
+                      {ch.tags.map((t, i) => (
+                        <span key={i} style={styles.tag}>{t}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Character Detail View
+// ---------------------------------------------------------------------------
+
+function CharacterDetail({ character, role, onBack, onUpdate, onDelete }) {
+  const ch = character
+  const [editing, setEditing] = useState(false)
+  const [form, setForm] = useState({})
+  const [relForm, setRelForm] = useState([])
+  const [saving, setSaving] = useState(false)
+
+  function startEdit() {
+    setForm({
+      description: ch.description || '',
+      backstory: ch.backstory || '',
+      tags: (ch.tags || []).join(', '),
+      portrait_url: ch.portrait_url || '',
+      race: ch.race || '',
+      class: ch.class || '',
+      alignment: ch.alignment || '',
+      status: ch.status || 'alive',
+    })
+    setRelForm(ch.relationships && ch.relationships.length > 0
+      ? ch.relationships.map(r => ({ ...r }))
+      : [])
+    setEditing(true)
+  }
+
+  async function save() {
+    setSaving(true)
+    const tags = form.tags.split(',').map(t => t.trim()).filter(Boolean)
+    const rels = relForm.filter(r => r.name.trim() && r.relation.trim())
+    const success = await onUpdate(ch.id, {
+      description: form.description.trim() || null,
+      backstory: form.backstory.trim() || null,
+      tags,
+      relationships: rels,
+      portrait_url: form.portrait_url.trim() || null,
+      race: form.race.trim() || null,
+      class: form.class.trim() || null,
+      alignment: form.alignment.trim() || null,
+      status: form.status,
+    })
+    if (success) setEditing(false)
+    setSaving(false)
+  }
+
+  return (
+    <div style={styles.detailContainer}>
+      <button style={styles.backBtn} onClick={onBack}>&larr; Back to Characters</button>
+
+      <div style={styles.detailHeader}>
+        {ch.portrait_url && (
+          <img src={ch.portrait_url} alt={ch.name} style={styles.portrait} />
+        )}
+        <div>
+          <h2 style={styles.detailName}>{ch.name}</h2>
+          <div style={styles.detailMeta}>
+            <span style={{
+              ...styles.typeBadge,
+              backgroundColor: typeColors[ch.type] || '#e2e8f0',
+            }}>{ch.type.toUpperCase()}</span>
+            {ch.race && <span style={styles.metaItem}>{ch.race}</span>}
+            {ch.class && <span style={styles.metaItem}>{ch.class}</span>}
+            {ch.level && <span style={styles.metaItem}>Level {ch.level}</span>}
+            {ch.alignment && <span style={styles.metaItem}>{ch.alignment}</span>}
+            <span style={{
+              ...styles.statusBadge,
+              backgroundColor: statusColors[ch.status] || '#e2e8f0',
+            }}>{ch.status}</span>
+          </div>
+        </div>
+      </div>
+
+      {editing ? (
+        <div style={styles.editForm}>
+          <div style={styles.row}>
+            <input style={{ ...styles.input, flex: 1 }} value={form.race}
+              onChange={e => setForm({ ...form, race: e.target.value })}
+              placeholder="Race" />
+            <input style={{ ...styles.input, flex: 1 }} value={form.class}
+              onChange={e => setForm({ ...form, class: e.target.value })}
+              placeholder="Class" />
+            <input style={{ ...styles.input, flex: 1 }} value={form.alignment}
+              onChange={e => setForm({ ...form, alignment: e.target.value })}
+              placeholder="Alignment" />
+            <select style={styles.select} value={form.status}
+              onChange={e => setForm({ ...form, status: e.target.value })}>
+              <option value="alive">Alive</option>
+              <option value="dead">Dead</option>
+              <option value="missing">Missing</option>
+              <option value="retired">Retired</option>
+            </select>
+          </div>
+          <textarea style={styles.textarea} value={form.description}
+            onChange={e => setForm({ ...form, description: e.target.value })}
+            placeholder="Description" rows={4} />
+          <textarea style={styles.textarea} value={form.backstory}
+            onChange={e => setForm({ ...form, backstory: e.target.value })}
+            placeholder="Backstory" rows={3} />
+          <input style={styles.input} value={form.tags}
+            onChange={e => setForm({ ...form, tags: e.target.value })}
+            placeholder="Tags (comma-separated)" />
+          <input style={styles.input} value={form.portrait_url}
+            onChange={e => setForm({ ...form, portrait_url: e.target.value })}
+            placeholder="Portrait image URL" />
+
+          <div style={styles.relSection}>
+            <span style={styles.relLabel}>Relationships</span>
+            {relForm.map((r, i) => (
+              <div key={i} style={styles.row}>
+                <input style={{ ...styles.input, flex: 1 }} value={r.name}
+                  onChange={e => {
+                    const copy = [...relForm]
+                    copy[i] = { ...copy[i], name: e.target.value }
+                    setRelForm(copy)
+                  }} placeholder="Name" />
+                <input style={{ ...styles.input, flex: 1 }} value={r.relation}
+                  onChange={e => {
+                    const copy = [...relForm]
+                    copy[i] = { ...copy[i], relation: e.target.value }
+                    setRelForm(copy)
+                  }} placeholder="Relation" />
+                <button style={styles.removeBtn}
+                  onClick={() => setRelForm(relForm.filter((_, j) => j !== i))}>x</button>
+              </div>
+            ))}
+            <button style={styles.addRelBtn}
+              onClick={() => setRelForm([...relForm, { name: '', relation: '' }])}>
+              + Add Relationship
+            </button>
+          </div>
+
+          <div style={styles.row}>
+            <button style={styles.button} onClick={save} disabled={saving}>
+              {saving ? 'Saving...' : 'Save Changes'}
+            </button>
+            <button style={styles.cancelBtn} onClick={() => setEditing(false)}>Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <div style={styles.detailBody}>
+          {ch.description && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Description</h3>
+              <p style={styles.sectionText}>{ch.description}</p>
+            </div>
+          )}
+
+          {ch.backstory && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Backstory</h3>
+              <p style={styles.sectionText}>{ch.backstory}</p>
+            </div>
+          )}
+
+          {ch.tags && ch.tags.length > 0 && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Tags</h3>
+              <div style={styles.tagRow}>
+                {ch.tags.map((t, i) => <span key={i} style={styles.tag}>{t}</span>)}
+              </div>
+            </div>
+          )}
+
+          {ch.relationships && ch.relationships.length > 0 && (
+            <div style={styles.section}>
+              <h3 style={styles.sectionTitle}>Relationships</h3>
+              <div style={styles.relList}>
+                {ch.relationships.map((r, i) => (
+                  <div key={i} style={styles.relItem}>
+                    <span style={styles.relName}>{r.name}</span>
+                    <span style={styles.relType}>{r.relation}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {role === 'dm' && (
+            <div style={styles.detailActions}>
+              <button style={styles.button} onClick={startEdit}>Edit</button>
+              <button style={styles.deleteBtn} onClick={() => onDelete(ch.id)}>Delete</button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Constants & Styles
+// ---------------------------------------------------------------------------
+
+const typeColors = {
+  pc: '#dbeafe',
+  npc: '#ede9fe',
+  companion: '#d1fae5',
+  deity: '#fef3c7',
+}
+
+const statusColors = {
+  alive: '#d1fae5',
+  dead: '#fee2e2',
+  missing: '#fef3c7',
+  retired: '#e2e8f0',
+}
+
+const styles = {
+  container: {
+    maxWidth: '720px',
+    margin: '0 auto',
+    padding: '1.5rem',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: '1rem',
+  },
+  title: {
+    margin: 0,
+    fontSize: '1.25rem',
+    color: '#1e293b',
+  },
+  button: {
+    padding: '0.5rem 1rem',
+    borderRadius: '8px',
+    backgroundColor: '#2563eb',
+    color: '#fff',
+    border: 'none',
+    fontSize: '0.875rem',
+    cursor: 'pointer',
+  },
+  cancelBtn: {
+    padding: '0.5rem 1rem',
+    borderRadius: '8px',
+    backgroundColor: 'transparent',
+    color: '#64748b',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.875rem',
+    cursor: 'pointer',
+  },
+  deleteBtn: {
+    padding: '0.5rem 1rem',
+    borderRadius: '8px',
+    backgroundColor: 'transparent',
+    border: '1px solid #fca5a5',
+    color: '#dc2626',
+    fontSize: '0.875rem',
+    cursor: 'pointer',
+  },
+  searchInput: {
+    width: '100%',
+    padding: '0.6rem 0.75rem',
+    borderRadius: '8px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.875rem',
+    outline: 'none',
+    marginBottom: '1rem',
+    boxSizing: 'border-box',
+  },
+  createForm: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    marginBottom: '1rem',
+    padding: '1rem',
+    borderRadius: '10px',
+    border: '1px solid #e2e8f0',
+    backgroundColor: '#f8fafc',
+  },
+  editForm: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+    marginTop: '1rem',
+  },
+  row: {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'center',
+  },
+  input: {
+    padding: '0.5rem 0.75rem',
+    borderRadius: '6px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.85rem',
+    outline: 'none',
+  },
+  select: {
+    padding: '0.5rem 0.75rem',
+    borderRadius: '6px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.85rem',
+    outline: 'none',
+    backgroundColor: '#fff',
+  },
+  textarea: {
+    padding: '0.5rem 0.75rem',
+    borderRadius: '6px',
+    border: '1px solid #cbd5e1',
+    fontSize: '0.85rem',
+    outline: 'none',
+    resize: 'vertical',
+    fontFamily: 'inherit',
+    lineHeight: 1.5,
+  },
+  relSection: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.35rem',
+  },
+  relLabel: {
+    fontSize: '0.8rem',
+    fontWeight: 600,
+    color: '#475569',
+  },
+  addRelBtn: {
+    padding: '0.3rem 0.6rem',
+    borderRadius: '6px',
+    backgroundColor: 'transparent',
+    border: '1px dashed #94a3b8',
+    color: '#64748b',
+    fontSize: '0.75rem',
+    cursor: 'pointer',
+    alignSelf: 'flex-start',
+  },
+  removeBtn: {
+    padding: '0.3rem 0.5rem',
+    borderRadius: '4px',
+    backgroundColor: 'transparent',
+    border: '1px solid #fca5a5',
+    color: '#dc2626',
+    fontSize: '0.75rem',
+    cursor: 'pointer',
+    lineHeight: 1,
+  },
+  muted: {
+    color: '#94a3b8',
+    fontSize: '0.9rem',
+  },
+  empty: {
+    textAlign: 'center',
+    padding: '3rem 1rem',
+    backgroundColor: '#f8fafc',
+    borderRadius: '12px',
+    border: '1px dashed #cbd5e1',
+  },
+  emptyText: {
+    margin: '0 0 0.25rem 0',
+    color: '#334155',
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+  card: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '0.75rem 1rem',
+    borderRadius: '10px',
+    border: '1px solid #e2e8f0',
+    backgroundColor: '#fff',
+    textAlign: 'left',
+    cursor: 'pointer',
+    width: '100%',
+    fontFamily: 'inherit',
+  },
+  cardRow: {
+    display: 'flex',
+    gap: '0.75rem',
+    alignItems: 'flex-start',
+  },
+  thumbnail: {
+    width: '48px',
+    height: '48px',
+    borderRadius: '8px',
+    objectFit: 'cover',
+    flexShrink: 0,
+  },
+  cardInfo: {
+    flex: 1,
+    minWidth: 0,
+  },
+  cardTop: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: '0.5rem',
+  },
+  cardName: {
+    fontSize: '0.95rem',
+    fontWeight: 600,
+    color: '#1e293b',
+  },
+  typeBadge: {
+    fontSize: '0.65rem',
+    fontWeight: 600,
+    padding: '0.15rem 0.4rem',
+    borderRadius: '4px',
+    color: '#334155',
+    flexShrink: 0,
+  },
+  meta: {
+    fontSize: '0.8rem',
+    color: '#64748b',
+  },
+  metaItem: {
+    fontSize: '0.8rem',
+    color: '#64748b',
+  },
+  preview: {
+    margin: '0.25rem 0 0 0',
+    fontSize: '0.8rem',
+    color: '#64748b',
+    lineHeight: 1.4,
+  },
+  tagRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.3rem',
+    marginTop: '0.35rem',
+  },
+  tag: {
+    fontSize: '0.65rem',
+    padding: '0.1rem 0.4rem',
+    borderRadius: '4px',
+    backgroundColor: '#f1f5f9',
+    color: '#475569',
+    border: '1px solid #e2e8f0',
+  },
+  // Detail styles
+  detailContainer: {
+    maxWidth: '720px',
+    margin: '0 auto',
+    padding: '1.5rem',
+  },
+  backBtn: {
+    padding: '0.4rem 0',
+    background: 'none',
+    border: 'none',
+    color: '#2563eb',
+    fontSize: '0.85rem',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+    marginBottom: '1rem',
+  },
+  detailHeader: {
+    display: 'flex',
+    gap: '1rem',
+    alignItems: 'flex-start',
+    marginBottom: '1.5rem',
+    paddingBottom: '1rem',
+    borderBottom: '1px solid #e2e8f0',
+  },
+  portrait: {
+    width: '80px',
+    height: '80px',
+    borderRadius: '10px',
+    objectFit: 'cover',
+    flexShrink: 0,
+  },
+  detailName: {
+    margin: '0 0 0.35rem 0',
+    fontSize: '1.35rem',
+    color: '#1e293b',
+  },
+  detailMeta: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.4rem',
+    alignItems: 'center',
+  },
+  statusBadge: {
+    fontSize: '0.65rem',
+    fontWeight: 600,
+    padding: '0.15rem 0.4rem',
+    borderRadius: '4px',
+    color: '#334155',
+  },
+  detailBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1.25rem',
+  },
+  section: {},
+  sectionTitle: {
+    margin: '0 0 0.35rem 0',
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    color: '#475569',
+    textTransform: 'uppercase',
+    letterSpacing: '0.03em',
+  },
+  sectionText: {
+    margin: 0,
+    fontSize: '0.9rem',
+    color: '#334155',
+    lineHeight: 1.6,
+    whiteSpace: 'pre-wrap',
+  },
+  relList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.35rem',
+  },
+  relItem: {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'center',
+    padding: '0.4rem 0.6rem',
+    borderRadius: '6px',
+    backgroundColor: '#f8fafc',
+    border: '1px solid #e2e8f0',
+  },
+  relName: {
+    fontSize: '0.85rem',
+    fontWeight: 600,
+    color: '#1e293b',
+  },
+  relType: {
+    fontSize: '0.8rem',
+    color: '#64748b',
+    fontStyle: 'italic',
+  },
+  detailActions: {
+    display: 'flex',
+    gap: '0.5rem',
+    paddingTop: '1rem',
+    borderTop: '1px solid #e2e8f0',
+  },
+}

--- a/supabase/migrations/00004_tags_relationships.sql
+++ b/supabase/migrations/00004_tags_relationships.sql
@@ -1,0 +1,33 @@
+-- ============================================================================
+-- TOME — Phase 4: Tags, Relationships, and Location Images
+-- ============================================================================
+-- Adds searchable tags (text[]) and relationships (jsonb) to characters and
+-- locations. Adds a general image_url to locations (separate from maps).
+-- ============================================================================
+
+-- Characters: tags and relationships
+ALTER TABLE public.characters
+  ADD COLUMN IF NOT EXISTS tags text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS relationships jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.characters.tags IS
+  'Searchable tags, e.g. {"tavern keeper", "quest giver", "ally"}.';
+COMMENT ON COLUMN public.characters.relationships IS
+  'Array of {name, relation} objects, e.g. [{"name":"Strahd","relation":"enemy"}].';
+
+-- Locations: tags, relationships, and image_url
+ALTER TABLE public.locations
+  ADD COLUMN IF NOT EXISTS tags text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS relationships jsonb NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS image_url text;
+
+COMMENT ON COLUMN public.locations.tags IS
+  'Searchable tags, e.g. {"safe haven", "dungeon", "shop"}.';
+COMMENT ON COLUMN public.locations.relationships IS
+  'Array of {name, relation} objects, e.g. [{"name":"Waterdeep","relation":"trade route"}].';
+COMMENT ON COLUMN public.locations.image_url IS
+  'General display image for this location.';
+
+-- GIN index for fast tag searches
+CREATE INDEX IF NOT EXISTS idx_characters_tags ON public.characters USING gin(tags);
+CREATE INDEX IF NOT EXISTS idx_locations_tags ON public.locations USING gin(tags);


### PR DESCRIPTION
 Summary

  - Added NPC browser page with full CRUD — create, view, edit, and delete NPCs with tag support
  - Added Location browser page with full CRUD — create, view, edit, and delete locations with tag support
  - Extended campaign tools backend with speed analytics and new NPC/Location data retrieval tools
  - Added Supabase migration for tags relationships schema
  - Wired new NPC and Location pages into the app router

  Test plan

  - Create, edit, and delete an NPC; verify tags persist correctly
  - Create, edit, and delete a Location; verify tags persist correctly
  - Confirm speed analytics data appears correctly in the campaign context
  - Run the Supabase migration (00004_tags_relationships.sql) on a clean schema and verify no errors
  - Verify routing to /npcs and /locations works from the campaign view